### PR TITLE
Fix/전적 엔티티 변경#47

### DIFF
--- a/backend/src/game/game.service.ts
+++ b/backend/src/game/game.service.ts
@@ -207,30 +207,30 @@ export class GameService {
     isForfeit: boolean,
     socketID: string | null
   ) => {
-    const [winner_id, loser_id, loser_score] = this.findRecordData(
+    const [winner, loser, loser_score] = this.findRecordData(
       roomInfo,
       isForfeit,
       socketID
     );
     if (isForfeit === true) {
       // 몰수패인 경우
-      this.setRoomInfoScore(roomInfo, winner_id);
+      this.setRoomInfoScore(roomInfo, winner);
     }
     const [type, mode] = this.getTypeModeName(roomInfo.type_mode);
     const {game_type, game_mode} = await this.getTypeModeID(type, mode);
     const record = this.recordRepository.create({
       game_type,
       game_mode,
-      winner_id,
-      loser_id,
+      winner,
+      loser,
       winner_score: 5,
       loser_score,
       is_forfeit: isForfeit,
     });
     await this.recordRepository.save(record);
     if (type === 'rank') {
-      await this.saveRankScore(winner_id, true);
-      await this.saveRankScore(loser_id, false);
+      await this.saveRankScore(winner, true);
+      await this.saveRankScore(loser, false);
     }
   };
 
@@ -301,8 +301,8 @@ export class GameService {
     return [winnerID, loserID, loser_score];
   };
 
-  setRoomInfoScore = (roomInfo: RoomInfo, winner_id: string) => {
-    const winnerLeft = this.isWinnerLeft(roomInfo, winner_id);
+  setRoomInfoScore = (roomInfo: RoomInfo, winner: string) => {
+    const winnerLeft = this.isWinnerLeft(roomInfo, winner);
     if (winnerLeft === true) {
       roomInfo.game_info.leftScore = 5;
       roomInfo.game_info.rightScore = 0;
@@ -312,8 +312,8 @@ export class GameService {
     }
   };
 
-  isWinnerLeft = (roomInfo: RoomInfo, winner_id: string): boolean => {
-    if (winner_id === roomInfo.users[0].user_id) {
+  isWinnerLeft = (roomInfo: RoomInfo, winner: string): boolean => {
+    if (winner === roomInfo.users[0].user_id) {
       return true;
     }
     return false;

--- a/backend/src/record/record.controller.ts
+++ b/backend/src/record/record.controller.ts
@@ -55,12 +55,12 @@ export class RecordController {
     );
   }
 
-  @Post('/test')
-  async PostTest(
+  @Get('/test')
+  async getTest(
     @Query('winner') winner: string,
     @Query('loser') loser: string
   ) {
-    this.recordService.PostTest(winner, loser);
+    this.recordService.getTest(winner, loser);
     console.log('winner: ', winner, '\nloser: ', loser);
   }
 }

--- a/backend/src/record/record.controller.ts
+++ b/backend/src/record/record.controller.ts
@@ -21,31 +21,17 @@ export class RecordController {
     return await this.recordService.getEntireRecords();
   }
 
-  // @Get('/:user_id')
-  // async getOneRecords(@Param('user_id') user_id: string): Promise<string> {
-  //   console.log('/:user_id');
-  //   return await this.recordService.getOneRecords(user_id);
-  // }
-
-  @Get('/simple')
+  @Get('simple')
   async getSimpleRecord(@Query('id') userID: string): Promise<SimpleRecordDto> {
-    // Validate query parameters
-    if (!userID || typeof userID !== 'string') {
-      throw new BadRequestException('Invalid query parameters');
-    }
     return await this.recordService.getSimpleRecord(userID);
   }
 
-  @Get('/detail')
+  @Get('detail')
   async getDetailRecord(
     @Query('id') userID: string,
     @Query('page') pageNo: number,
     @Query('size') pageSize: number
   ): Promise<Record[]> {
-    // Validate query parameters
-    if (!userID || typeof userID !== 'string' || isNaN(pageNo)) {
-      throw new BadRequestException('Invalid query parameters');
-    }
     let clientID = 'user1';
     return await this.recordService.getDetailRecord(
       clientID,
@@ -55,12 +41,19 @@ export class RecordController {
     );
   }
 
-  @Get('/test')
-  async getTest(
+  // For Test
+  @Get('save')
+  async getSave(
     @Query('winner') winner: string,
     @Query('loser') loser: string
   ) {
-    this.recordService.getTest(winner, loser);
+    this.recordService.getSave(winner, loser);
     console.log('winner: ', winner, '\nloser: ', loser);
+  }
+
+  // For Test
+  @Get('join-test')
+  async getJoinTest(@Query('user') user: string) {
+    return await this.recordService.getJoinTest(user);
   }
 }

--- a/backend/src/record/record.controller.ts
+++ b/backend/src/record/record.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Get,
   Param,
+  Post,
   Query,
   ValidationPipe,
 } from '@nestjs/common';
@@ -35,7 +36,7 @@ export class RecordController {
     return await this.recordService.getSimpleRecord(userID);
   }
 
-  @Get('detail')
+  @Get('/detail')
   async getDetailRecord(
     @Query('id') userID: string,
     @Query('page') pageNo: number,
@@ -52,5 +53,14 @@ export class RecordController {
       pageNo,
       pageSize
     );
+  }
+
+  @Post('/test')
+  async PostTest(
+    @Query('winner') winner: string,
+    @Query('loser') loser: string
+  ) {
+    this.recordService.PostTest(winner, loser);
+    console.log('winner: ', winner, '\nloser: ', loser);
   }
 }

--- a/backend/src/record/record.entity.ts
+++ b/backend/src/record/record.entity.ts
@@ -14,6 +14,12 @@ export class Record {
   @PrimaryGeneratedColumn()
   id: number;
 
+  @Column()
+  winnerId: string;
+
+  @Column()
+  loserId: string;
+
   @ManyToOne(() => User, user_id => user_id.win_records)
   @JoinColumn({name: 'winnerId'})
   winner: string;

--- a/backend/src/record/record.entity.ts
+++ b/backend/src/record/record.entity.ts
@@ -1,17 +1,26 @@
-import {Column, Entity, ManyToOne, PrimaryGeneratedColumn} from 'typeorm';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 import {Mode} from './mode/mode.entity';
 import {Type} from './type/type.entity';
+import {User} from 'src/user/user.entitiy';
 
 @Entity('game_record')
 export class Record {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column()
-  winner_id: string;
+  @ManyToOne(() => User, user_id => user_id.win_records)
+  @JoinColumn({name: 'winnerId'})
+  winner: string;
 
-  @Column()
-  loser_id: string;
+  @ManyToOne(() => User, user_id => user_id.lose_records)
+  @JoinColumn({name: 'loserId'})
+  loser: string;
 
   @Column({default: 0})
   winner_score: number;

--- a/backend/src/record/record.repository.ts
+++ b/backend/src/record/record.repository.ts
@@ -17,7 +17,7 @@ export class RecordRepository extends Repository<Record> {
   }
   async getRecentGames(userID: string, limit: number): Promise<Record[]> {
     return this.createQueryBuilder('record')
-      .where('record.winner_id = :userID OR record.loser_id = :userID', {
+      .where('record.winner = :userID OR record.loser = :userID', {
         userID,
       })
       .orderBy('record.date', 'DESC')

--- a/backend/src/record/record.repository.ts
+++ b/backend/src/record/record.repository.ts
@@ -24,4 +24,15 @@ export class RecordRepository extends Repository<Record> {
       .take(limit)
       .getMany();
   }
+
+  async getDetailGames(userID: string, pageSize: number, skip: number) {
+    return this.createQueryBuilder('record')
+      .leftJoinAndSelect('record.winner', 'winner') // Left join with winner
+      .leftJoinAndSelect('record.loser', 'loser') // Left join with loser
+      .where('record.winnerId = :userID OR record.loserId = :userID', {userID})
+      .orderBy('record.id', 'DESC')
+      .take(pageSize)
+      .skip(skip)
+      .getMany();
+  }
 }

--- a/backend/src/record/record.service.ts
+++ b/backend/src/record/record.service.ts
@@ -50,17 +50,17 @@ export class RecordService {
     const user = await this.userRepository.findOneBy({user_id: userID});
     const win: number = await this.recordRepository.count({
       where: {
-        winner_id: userID,
+        winner: userID,
       },
     });
     const lose: number = await this.recordRepository.count({
       where: {
-        loser_id: userID,
+        loser: userID,
       },
     });
     const forfeit: number = await this.recordRepository.count({
       where: {
-        loser_id: userID,
+        loser: userID,
         is_forfeit: true,
       },
     });
@@ -97,8 +97,8 @@ export class RecordService {
     };
 
     recentGames.forEach((record, idx) => {
-      const {winner_id} = record;
-      if (winner_id === userID) {
+      const {winner} = record;
+      if (winner === userID) {
         recentRecord[idx] = '승';
       } else {
         recentRecord[idx] = '패';
@@ -128,12 +128,33 @@ export class RecordService {
     //   },
     // });
     const skip = (pageNo - 1) * pageSize;
-    const [result, total] = await this.recordRepository.findAndCount({
-      where: [{winner_id: userID}, {loser_id: userID}],
+    // const record = await this.recordRepository.
+    const result = await this.recordRepository.find({
+      // relations: {
+      //   winner: true,
+      // },
+      where: [{winner: userID}, {loser: userID}],
       order: {id: 'DESC'},
       take: pageSize,
       skip: skip,
     });
+    // result.forEach((value) => {
+    //   await this.userRepository.findOneBy(value.winner)
+    // });
+
     return result;
   };
+
+  PostTest(winner: string, loser: string) {
+    const record = this.recordRepository.create({
+      winner,
+      loser,
+      winner_score: 5,
+      loser_score: 5,
+      is_forfeit: false,
+      game_mode: 1,
+      game_type: 1,
+    });
+    this.recordRepository.save(record);
+  }
 }

--- a/backend/src/record/record.service.ts
+++ b/backend/src/record/record.service.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   Injectable,
   InternalServerErrorException,
+  NotFoundException,
 } from '@nestjs/common';
 import {InjectRepository} from '@nestjs/typeorm';
 import {RecordRepository} from './record.repository';
@@ -21,7 +22,6 @@ import {DetailRecordDto} from './dto/detail-record.dto';
 @Injectable()
 export class RecordService {
   constructor(
-    // @InjectRepository(RecordRepository)
     private recordRepository: RecordRepository,
     private userRepository: UserRepository
   ) {}
@@ -41,7 +41,7 @@ export class RecordService {
     }
     const user = await this.userRepository.findOneBy({user_id: userID});
     if (!user) {
-      throw new BadRequestException();
+      throw new NotFoundException('User not found');
     }
     let win = 0,
       lose = 0;
@@ -107,6 +107,10 @@ export class RecordService {
   ): Promise<Record[] | null> => {
     if (!userID || typeof userID !== 'string' || isNaN(pageNo)) {
       throw new BadRequestException('Invalid request format');
+    }
+    const user = await this.userRepository.findOneBy({user_id: userID});
+    if (!user) {
+      throw new NotFoundException('User not found');
     }
     const skip = (pageNo - 1) * pageSize;
     return await this.recordRepository.getDetailGames(userID, pageSize, skip);

--- a/backend/src/record/record.service.ts
+++ b/backend/src/record/record.service.ts
@@ -104,7 +104,7 @@ export class RecordService {
     userID: string,
     pageNo: number,
     pageSize: number
-  ): Promise<Record[] | null> => {
+  ): Promise<Record[]> => {
     if (!userID || typeof userID !== 'string' || isNaN(pageNo)) {
       throw new BadRequestException('Invalid request format');
     }

--- a/backend/src/record/record.service.ts
+++ b/backend/src/record/record.service.ts
@@ -48,19 +48,28 @@ export class RecordService {
 
   getSimpleRecord = async (userID: string): Promise<SimpleRecordDto> => {
     const user = await this.userRepository.findOneBy({user_id: userID});
-    const win: number = await this.recordRepository.count({
-      where: {
-        winner: userID,
-      },
-    });
-    const lose: number = await this.recordRepository.count({
-      where: {
-        loser: userID,
-      },
-    });
+    // const win: number = await this.recordRepository.count({
+    //   where: {
+    //     winner: userID,
+    //   },
+    // });
+    console.log('user: ', userID);
+    let win = 0,
+      lose = 0;
+    if (user.win_records) {
+      win = user.win_records.length;
+    }
+    if (user.lose_records) {
+      lose = user.lose_records.length;
+    }
+    // const lose: number = await this.recordRepository.count({
+    //   where: {
+    //     loser: userID,
+    //   },
+    // });
     const forfeit: number = await this.recordRepository.count({
       where: {
-        loser: userID,
+        loserId: userID,
         is_forfeit: true,
       },
     });
@@ -145,12 +154,12 @@ export class RecordService {
     return result;
   };
 
-  PostTest(winner: string, loser: string) {
+  getTest(winner: string, loser: string) {
     const record = this.recordRepository.create({
-      winner,
-      loser,
+      winnerId: winner,
+      loserId: loser,
       winner_score: 5,
-      loser_score: 5,
+      loser_score: 0,
       is_forfeit: false,
       game_mode: 1,
       game_type: 1,

--- a/backend/src/user/user.entitiy.ts
+++ b/backend/src/user/user.entitiy.ts
@@ -1,4 +1,5 @@
 import {BlockList, ChatBan, ChatMember, FriendList} from 'src/chat/chat.entity';
+import {Record} from 'src/record/record.entity';
 import {
   Column,
   Entity,
@@ -45,4 +46,10 @@ export class User {
 
   @Column({nullable: true})
   two_factor_auth_secret: string;
+
+  @OneToMany(() => Record, record => record.winner)
+  win_records: Record[];
+
+  @OneToMany(() => Record, record => record.loser)
+  lose_records: Record[];
 }

--- a/backend/test_query.sql
+++ b/backend/test_query.sql
@@ -1,4 +1,16 @@
 INSERT INTO users (user_id, user_pw, user_nickname, user_image, is_2fa_enabled, rank_score)
 VALUES 
-  ('user1', '1234', 'nick1', 'logo.jpg', false, 1000),
-  ('user2', '1234', 'nick2', 'logo.jpg', false, 1000);
+  ('user1', '1234', 'nick1', '/images/logo.jpeg', false, 1000),
+  ('user2', '1234', 'nick2', '/images/logo.jpeg', false, 1000),
+  ('user3', '1234', 'nick3', '/images/logo.jpeg', false, 1000),
+  ('user4', '1234', 'nick4', '/images/logo.jpeg', false, 1000);
+
+INSERT INTO game_type (id, type)
+VALUES 
+  (1, '일반'),
+  (2, '랭크');
+
+INSERT INTO game_mode (id, mode)
+VALUES 
+  (1, '일반'),
+  (2, '가속');


### PR DESCRIPTION
# PR 종류
이 PR에는 어떤 종류의 변화가 있었나요?

<!-- 해당하는 아래의 항목에 [x] 로 표시해주세요 -->

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 스타일 변경 (포맷팅, 지역 변수 등)
- [ ] 리팩토링 (기능적 변화가 없는 경우)
- [ ] 빌드와 관련한 변경
- [ ] 문서 내용 변경
- [ ] 기타 사항은 우측에 작성해주세요:


# 기존에 작동하던 방식은 무엇이었나요?
<!-- 수정하려고 하는 것의 기존 작동 방식을 설명하거나 이와 관련한 이슈를 링크 걸어주세요. -->

Issue Number: N/A

- 클라이언트가 상세 전적을 요청하면 경기 기록에 유저의 ID를 표기하여 반환

# 새로운 작동 방식은 무엇인가요?

- 상세 전적을 요청할 때, 유저의 닉네임까지 반환하도록 변경
- Record 엔티티에 User 엔티티를 left join 하였음.
  -  Record 엔티티의 winner, loser키에 값으로 User 엔티티를 포함하여 반환

# 이번 PR에 큰 변화가 있었나요?

- [ ] 예
- [ ] 아니오


<!-- 만약 이번 PR에 큰 변화가 있었다면, 기존에 작동하던 코드에 미칠 영향을 설명해주세요 -->


# 기타 참고할 정보 또는 스크린샷

```json
[
    {
        "id": 6,
        "winnerId": "user1",
        "loserId": "user2",
        "winner_score": 5,
        "loser_score": 0,
        "is_forfeit": false,
        "date": "2023-08-13T16:06:23.134Z",
        "winner": {
            "user_id": "user1",
            "user_pw": "1234",
            "user_nickname": "nick1",
            "user_image": "/images/logo.jpeg",
            "is_2fa_enabled": false,
            "rank_score": 1000,
            "two_factor_auth_secret": null
        },
        "loser": {
            "user_id": "user2",
            "user_pw": "1234",
            "user_nickname": "nick2",
            "user_image": "/images/logo.jpeg",
            "is_2fa_enabled": false,
            "rank_score": 1000,
            "two_factor_auth_secret": null
        }
    },

...

]
```
