### PR TITLE
fix: record에 user를 join하는 과정에서 암호가 포함되는 문제 해결

### DIFF
--- a/backend/src/record/record.repository.ts
+++ b/backend/src/record/record.repository.ts
@@ -27,8 +27,18 @@ export class RecordRepository extends Repository<Record> {
 
   async getDetailGames(userID: string, pageSize: number, skip: number) {
     return this.createQueryBuilder('record')
-      .leftJoinAndSelect('record.winner', 'winner') // Left join with winner
-      .leftJoinAndSelect('record.loser', 'loser') // Left join with loser
+      .addSelect([
+        'winner.user_id',
+        'winner.user_nickname',
+        // 'winner.user_image',
+      ])
+      .addSelect([
+        'loser.user_id',
+        'loser.user_nickname',
+        // 'loser.user_image'
+      ])
+      .leftJoin('record.winner', 'winner')
+      .leftJoin('record.loser', 'loser')
       .where('record.winnerId = :userID OR record.loserId = :userID', {userID})
       .orderBy('record.id', 'DESC')
       .take(pageSize)


### PR DESCRIPTION
# PR 종류
이 PR에는 어떤 종류의 변화가 있었나요?

<!-- 해당하는 아래의 항목에 [x] 로 표시해주세요 -->

- [x] 버그 수정
- [ ] 기능 추가
- [ ] 코드 스타일 변경 (포맷팅, 지역 변수 등)
- [ ] 리팩토링 (기능적 변화가 없는 경우)
- [ ] 빌드와 관련한 변경
- [ ] 문서 내용 변경
- [ ] 기타 사항은 우측에 작성해주세요:


# 기존에 작동하던 방식은 무엇이었나요?
<!-- 수정하려고 하는 것의 기존 작동 방식을 설명하거나 이와 관련한 이슈를 링크 걸어주세요. -->

전적 조회 요청을 받으면 컨트롤러의 getDetailRecord 함수가 유저의 모든 정보를 함께 전송하였음.

```
[
    {
        "id": 1,
        "winnerId": "user1",
        "loserId": "user2",
        "winner_score": 5,
        "loser_score": 0,
        "is_forfeit": false,
        "date": "2023-08-15T17:10:30.300Z",
        "winner": {
            "user_id": "user1",
            "user_pw": "1234",
            "user_nickname": "nick1",
            "user_image": "/images/logo.jpeg",
            "is_2fa_enabled": false,
            "rank_score": 999,
            "two_factor_auth_secret": null
        },
        "loser": {
            "user_id": "user2",
            "user_pw": "1234",
            "user_nickname": "nick2",
            "user_image": "/images/logo.jpeg",
            "is_2fa_enabled": false,
            "rank_score": 1000,
            "two_factor_auth_secret": null
        }
    }
]
```

Issue Number: 58


# 새로운 작동 방식은 무엇인가요?

사용자의 id, 닉네임만 함께 전송하도록 변경하였음.

# 이번 PR에 큰 변화가 있었나요?

- [ ] 예
- [x] 아니오


<!-- 만약 이번 PR에 큰 변화가 있었다면, 기존에 작동하던 코드에 미칠 영향을 설명해주세요 -->


# 기타 참고할 정보 또는 스크린샷

```
[
    {
        "id": 1,
        "winnerId": "user1",
        "loserId": "user2",
        "winner_score": 5,
        "loser_score": 0,
        "is_forfeit": false,
        "date": "2023-08-15T17:10:30.300Z",
        "winner": {
            "user_id": "user1",
            "user_nickname": "nick1"
        },
        "loser": {
            "user_id": "user2",
            "user_nickname": "nick2"
        }
    }
]
```
