### PR TITLE
🐛 fix: 프로필 조회 대상의 아이디로 API 요청하도록 수정

### DIFF
--- a/frontend/src/components/Record/RecordSummary.tsx
+++ b/frontend/src/components/Record/RecordSummary.tsx
@@ -5,12 +5,15 @@ import {useEffect, useState} from 'react';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Chip from '@mui/material/Chip';
-import Divider from '@mui/material/Divider';
 import Typography from '@mui/material/Typography';
 
 import apiManager from '@/api/apiManager';
+import {UserType} from '@/types/UserContext';
+import axios from 'axios';
+import {useAlertSnackbar} from '@/hooks/useAlertSnackbar';
 
-function RecordSummary() {
+function RecordSummary({user_info}: {user_info: UserType}) {
+  const {openAlertSnackbar} = useAlertSnackbar();
   const [recentRecord, setRecentRecord] = useState<string[]>([]);
   const [win, setWin] = useState<number>(0);
   const [lose, setLose] = useState<number>(0);
@@ -23,9 +26,9 @@ function RecordSummary() {
   useEffect(() => {
     const getUserRecord = async () => {
       try {
-        //TODO: id 를 현재 보고 있는 유저의 아이디로 변경하기
-        const response = await apiManager.get('/record/simple?id=user1');
-        console.log(response);
+        const response = await apiManager.get(
+          `/record/simple?id=${user_info.id}`
+        );
         let numberWin = 0;
         let numberLose = 0;
         const recentRecord: string[] = response.data.recent_record;
@@ -55,6 +58,9 @@ function RecordSummary() {
         setRankScore(numberRankScore);
       } catch (error) {
         console.log(error);
+        if (axios.isAxiosError(error)) {
+          openAlertSnackbar({message: error.response?.data.message});
+        }
       }
     };
 

--- a/frontend/src/components/Record/RecordTable.tsx
+++ b/frontend/src/components/Record/RecordTable.tsx
@@ -70,7 +70,6 @@ function RecordTable({intraId, type}: {intraId: string; type: string}) {
   // Avoid a layout jump when reaching the last page with empty rows.
   const emptyRows =
     page > 0 ? Math.max(0, (1 + page) * rowsPerPage - totalCounts) : 0;
-  console.log(emptyRows);
 
   const handleChangePage = (
     event: React.MouseEvent<HTMLButtonElement> | null,

--- a/frontend/src/components/UserProfileModal/index.tsx
+++ b/frontend/src/components/UserProfileModal/index.tsx
@@ -30,7 +30,7 @@ function UserProfileModalAction({user_info}: {user_info: UserType}) {
       </Box>
       <Divider sx={{mt: 2, mb: 2}} />
       <Box display="flex" flexDirection="column">
-        <RecordSummary />
+        <RecordSummary user_info={user_info} />
       </Box>
       <Box display="flex" flexDirection="column">
         <DetailRecord user_info={user_info} />


### PR DESCRIPTION
# PR 종류
이 PR에는 어떤 종류의 변화가 있었나요?

<!-- 해당하는 아래의 항목에 [x] 로 표시해주세요 -->

- [x] 버그 수정
- [ ] 기능 추가
- [ ] 코드 스타일 변경 (포맷팅, 지역 변수 등)
- [ ] 리팩토링 (기능적 변화가 없는 경우)
- [ ] 빌드와 관련한 변경
- [ ] 문서 내용 변경
- [ ] 기타 사항은 우측에 작성해주세요:


# 기존에 작동하던 방식은 무엇이었나요?
<!-- 수정하려고 하는 것의 기존 작동 방식을 설명하거나 이와 관련한 이슈를 링크 걸어주세요. -->

Issue Number: N/A


# 새로운 작동 방식은 무엇인가요?

simple record 를 조회하는 API 에 하드코딩한 유저 아이디 때문에 프로필이 정확하게 표시되지 않는 문제가 있었습니다.

그래서 현재 프로필을 조회하는 유저의 아이디로 API 요청을 보내도록 수정했습니다.

# 이번 PR에 큰 변화가 있었나요?

- [ ] 예
- [ ] 아니오


<!-- 만약 이번 PR에 큰 변화가 있었다면, 기존에 작동하던 코드에 미칠 영향을 설명해주세요 -->


# 기타 참고할 정보 또는 스크린샷
