### PR TITLE
Fix/게임 몰수패 처리#108

### DIFF
--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -140,7 +140,7 @@ export class GameGateway implements OnGatewayDisconnect {
     if (userInfo && userInfo.is_gaming === true) {
       return true;
     }
-    this.logger.log('게임 소켓 연결 해제');
+    return false;
   }
 
   createGameRoom(userId: string, gameUsers: GameUser[]): string {

--- a/backend/src/game/game.service.ts
+++ b/backend/src/game/game.service.ts
@@ -372,25 +372,6 @@ export class GameService {
     return false;
   };
 
-  // getTypeModeID = (
-  //   type: string,
-  //   mode: string
-  // ): { game_type: number; game_mode: number } => {
-  //   let typeID: number;
-  //   let modeID: number;
-  //   if (type === 'normal') {
-  //     typeID === 1;
-  //   } else {
-  //     typeID === 2;
-  //   }
-  //   if (mode === 'easy') {
-  //     modeID === 1;
-  //   } else {
-  //     modeID === 2;
-  //   }
-  //   return { game_type: typeID, game_mode: modeID }
-  // };
-
   getTypeModeID = (
     roomInfo: RoomInfo
   ): {game_type: number; game_mode: number} => {

--- a/backend/src/user/user.gateway.ts
+++ b/backend/src/user/user.gateway.ts
@@ -36,8 +36,6 @@ export class UserGateway implements OnGatewayConnection, OnGatewayDisconnect {
   }
 
   handleDisconnect(@ConnectedSocket() socket: Socket) {
-    const userID = socket.handshake.query.user_id as string;
-    this.socketArray.removeSocketArray(userID);
     this.logger.log(`${socket.id} 웹소켓 연결 해제`);
   }
 

--- a/frontend/src/components/layout/MainLayout/index.tsx
+++ b/frontend/src/components/layout/MainLayout/index.tsx
@@ -112,6 +112,7 @@ function MainLayout({children}: MainLayoutProps) {
         socketIo.on('token-expire', roomId => {
           // 서버가 연결을 끊은 경우 (ex, JWT 만료)
           sessionStorage.clear();
+          openAlertSnackbar({message: '토큰이 만료되었습니다. 다시 로그인해주세요.'});
           router.push('/');
           // if (roomId) {
           socketIo.emit('leave-room', {room_id: roomId, state: true});

--- a/frontend/src/pages/main/game/index.tsx
+++ b/frontend/src/pages/main/game/index.tsx
@@ -1,12 +1,24 @@
 'use client';
 
+import {useEffect, useContext} from 'react';
+import {useRecoilValue} from 'recoil';
+
 import {inviteGameState} from '@/states/inviteGame';
 import Game from '@/components/game/Game';
 import InviteGame from '@/components/game/InviteGame';
-import {useRecoilValue} from 'recoil';
+import {UserContext} from '@/components/layout/MainLayout/Context';
 
 function GameManager() {
   const invite_game_state = useRecoilValue(inviteGameState);
+  const {chat_socket} = useContext(UserContext);
+  
+  useEffect(() => {
+    return () => {
+      if (chat_socket) {
+        chat_socket.emit('exit_game');
+      }
+    }
+  }, []);
 
   return <>{invite_game_state === null ? <Game /> : <InviteGame />}</>;
 }

--- a/frontend/src/pages/user/login/index.tsx
+++ b/frontend/src/pages/user/login/index.tsx
@@ -70,6 +70,10 @@ function LoginPage() {
             openAlertSnackbar({message: '비밀번호가 일치하지 않습니다.'});
             break;
           }
+          case HTTP_STATUS.CONFLICT: {
+            openAlertSnackbar({message: '이미 로그인한 계정입니다.'});
+            break;
+          }
           default: {
             openAlertSnackbar({message: '오류가 발생했습니다.'});
             break;


### PR DESCRIPTION
# PR 종류
이 PR에는 어떤 종류의 변화가 있었나요?

<!-- 해당하는 아래의 항목에 [x] 로 표시해주세요 -->

- [x] 버그 수정
- [x] 기능 추가
- [ ] 코드 스타일 변경 (포맷팅, 지역 변수 등)
- [ ] 리팩토링 (기능적 변화가 없는 경우)
- [ ] 빌드와 관련한 변경
- [ ] 문서 내용 변경
- [ ] 기타 사항은 우측에 작성해주세요:


# 기존에 작동하던 방식은 무엇이었나요?
<!-- 수정하려고 하는 것의 기존 작동 방식을 설명하거나 이와 관련한 이슈를 링크 걸어주세요. -->

Issue Number: N/A


# 새로운 작동 방식은 무엇인가요?

소켓 통신 시 jwt 토큰이 만료된 경우 예외처리를 추가했습니다. 

## 백엔드

- 유저의 소켓이 끊긴 경우, 몰수패 처리
- 게임 중 다른 페이지로 이동한 경우, 몰수패 처리
- 게임을 초대했는데, 응답 받는 사람이 토큰이 만료된 경우, 초대자에게 이벤트 전송
- 랜덤 매칭에 참여하려는데 토큰이 만료된 경우, 유저에게 이벤트 전송
- 소켓을 통해 유저의 아이디를 가져오는 함수에서 토큰이 만료된 경우의 예외 처리

## 프론트

- 게임 중에 게임 페이지에서 벗어나면 `exit-game` 이벤트 서버로 전송해서 몰수패 처리
- 소켓 통신 중 token-expire 이벤트 발생하면 로그인 페이지 리다이렉트 및 snackbar 출력
- 동시 로그인을 시도하는 경우 로그인 페이지에서 snackbar 출력


# 이번 PR에 큰 변화가 있었나요?

- [ ] 예
- [ ] 아니오


<!-- 만약 이번 PR에 큰 변화가 있었다면, 기존에 작동하던 코드에 미칠 영향을 설명해주세요 -->


# 기타 참고할 정보 또는 스크린샷
